### PR TITLE
[codex] Add Alchemy fork tests CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+  alchemy-fork-test:
+    name: Alchemy fork tests
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      JPYC_ALCHEMY_API_KEY: ${{ secrets.JPYC_ALCHEMY_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Run Alchemy fork tests
+        run: npm run test:fork:alchemy


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow with a typecheck job.
- Add an Alchemy-backed Anvil fork test job using the `production` environment and `JPYC_ALCHEMY_API_KEY` secret.
- Install Foundry in CI before running `npm run test:fork:alchemy`.

## Validation
- `npm run typecheck`
- `npm run test:fork:alchemy` locally with Ethereum, Polygon, and Avalanche enabled on the Alchemy app.

Closes #1