### PR TITLE
[codex] Prepare npm package publishing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 YourBright, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# JPYC CLI
+
+Local-first JPYC command-line tooling for wallets, account queries, contract calls, and transfers.
+
+## Install
+
+```bash
+npm install -g @yourbright/jpyc-cli
+```
+
+## Usage
+
+```bash
+jpyc wallet create --id default --output json
+jpyc wallet list --output json
+```
+
+Set RPC URLs with environment variables before account or transfer commands:
+
+```bash
+export JPYC_POLYGON_RPC_URL="https://polygon-mainnet.g.alchemy.com/v2/<key>"
+jpyc account balance --wallet default --network polygon --tokens native,jpyc --output json
+```
+
+Wallet data is stored under `JPYC_CLI_HOME` when set, otherwise `~/.jpyc-cli`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,24 +7,27 @@
     "": {
       "name": "@yourbright/jpyc-cli",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
-        "@noble/ciphers": "^2.2.0"
+        "@noble/ciphers": "^2.2.0",
+        "viem": "^2.48.4"
       },
       "bin": {
-        "jpyc": "dist/cli/index.js"
+        "jpyc": "dist/cli/main.js"
       },
       "devDependencies": {
         "@types/node": "^20.19.2",
         "typescript": "^5.9.3",
-        "viem": "^2.48.4",
         "vitest": "^4.0.15"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "dev": true
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -96,7 +99,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -111,7 +113,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -380,7 +381,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -389,7 +389,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
       "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
-      "dev": true,
       "dependencies": {
         "@noble/curves": "~1.9.0",
         "@noble/hashes": "~1.8.0",
@@ -403,7 +402,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
       "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
-      "dev": true,
       "dependencies": {
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
@@ -569,7 +567,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -637,8 +634,7 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -684,7 +680,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
       "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -985,7 +980,6 @@
       "version": "0.14.20",
       "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
       "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1015,7 +1009,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1186,7 +1179,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1205,7 +1198,6 @@
       "version": "2.48.4",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
       "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1417,7 +1409,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,30 @@
 {
   "name": "@yourbright/jpyc-cli",
   "version": "0.0.0",
-  "private": true,
+  "description": "Local-first JPYC command-line tooling",
+  "license": "MIT",
   "type": "module",
   "bin": {
-    "jpyc": "./dist/cli/index.js"
+    "jpyc": "./dist/cli/main.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yourbright-jp/jpyc-cli.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run typecheck && npm run build",
     "test": "npm run test:fork",
     "test:fork": "RUN_ANVIL_FORK_TESTS=1 vitest run tests/anvil/jpyc-fork.test.ts",
     "test:fork:alchemy": "node scripts/run-fork-with-alchemy.mjs",
@@ -16,10 +34,10 @@
   "devDependencies": {
     "@types/node": "^20.19.2",
     "typescript": "^5.9.3",
-    "viem": "^2.48.4",
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@noble/ciphers": "^2.2.0"
+    "@noble/ciphers": "^2.2.0",
+    "viem": "^2.48.4"
   }
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { createJpycCli } from './index.js';
+
+export function resolveCliHomeDir(env: Record<string, string | undefined>) {
+  if (env.JPYC_CLI_HOME) return env.JPYC_CLI_HOME;
+  const home = env.HOME ?? env.USERPROFILE;
+  if (!home) throw new Error('HOME or JPYC_CLI_HOME is required');
+  return join(home, '.jpyc-cli');
+}
+
+export async function runCli(argv = process.argv.slice(2), env = process.env) {
+  const cli = createJpycCli({
+    homeDir: resolveCliHomeDir(env),
+    env: Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined)),
+  });
+  const result = await cli.run(argv);
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  return result.exitCode;
+}
+
+export function isCliEntrypoint(moduleUrl: string, argvPath: string | undefined) {
+  if (!argvPath) return false;
+  const argvUrl = pathToFileURL(argvPath).href;
+  if (moduleUrl === argvUrl) return true;
+  try {
+    return moduleUrl === pathToFileURL(realpathSync(argvPath)).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isCliEntrypoint(import.meta.url, process.argv[1])) {
+  runCli().then(
+    (exitCode) => {
+      process.exitCode = exitCode;
+    },
+    (error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    },
+  );
+}

--- a/tests/cli-main.test.ts
+++ b/tests/cli-main.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { pathToFileURL } from 'node:url';
+
+import { isCliEntrypoint, resolveCliHomeDir } from '../src/cli/main.js';
+
+describe('CLI main entrypoint', () => {
+  it('uses JPYC_CLI_HOME when provided', () => {
+    expect(resolveCliHomeDir({ JPYC_CLI_HOME: '/tmp/jpyc-home' })).toBe('/tmp/jpyc-home');
+  });
+
+  it('falls back to a user-scoped home directory', () => {
+    expect(resolveCliHomeDir({ HOME: '/home/alice' })).toBe('/home/alice/.jpyc-cli');
+  });
+
+  it('detects execution through the compiled bin path', () => {
+    const binPath = '/tmp/jpyc-global/bin/jpyc';
+
+    expect(isCliEntrypoint(pathToFileURL(binPath).href, binPath)).toBe(true);
+  });
+});

--- a/tests/package-publish.test.ts
+++ b/tests/package-publish.test.ts
@@ -1,0 +1,30 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+describe('npm publish package metadata', () => {
+  it('points the jpyc binary at the built CLI entrypoint', async () => {
+    const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
+
+    expect(packageJson.private).not.toBe(true);
+    expect(packageJson.bin).toEqual({ jpyc: './dist/cli/main.js' });
+    expect(packageJson.scripts).toMatchObject({
+      build: 'tsc -p tsconfig.build.json',
+      prepublishOnly: 'npm run typecheck && npm run build',
+    });
+  });
+
+  it('limits npm package contents to runtime files', async () => {
+    const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
+
+    expect(packageJson.files).toEqual(['dist', 'README.md', 'LICENSE']);
+    expect(packageJson.engines).toEqual({ node: '>=20.19.0' });
+    expect(packageJson.publishConfig).toEqual({ access: 'public' });
+  });
+
+  it('ships runtime EVM dependencies as production dependencies', async () => {
+    const packageJson = JSON.parse(await readFile('package.json', 'utf8'));
+
+    expect(packageJson.dependencies).toHaveProperty('viem');
+    expect(packageJson.devDependencies).not.toHaveProperty('viem');
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"],
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests/**/*.ts", "vitest.config.ts"]
+}


### PR DESCRIPTION
## Summary
- Add a built CLI entrypoint for the `jpyc` npm binary.
- Add TypeScript build config, README, LICENSE, and npm publish metadata.
- Move `viem` into production dependencies so the installed CLI can run.
- Add tests for publish metadata and CLI home/entrypoint behavior.

## Validation
- `npx vitest run tests/package-publish.test.ts tests/cli-main.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run`
- Local install with `npm install --global --prefix /tmp/jpyc-global .`, then `jpyc wallet create` and `jpyc wallet list`
- `npm publish --dry-run --access public`
- `npm run test:fork:alchemy`

## Publish note
The package name is not currently published on npm, but this environment is not logged into npm. Actual publish still requires `npm login` and a deliberate `npm publish --access public`.