### PR TITLE
Add Japanese README and JPYC CLI skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 .env
 .env.local
 *.log
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # JPYC CLI
 
-Local-first JPYC command-line tooling for wallets, account queries, contract calls, and transfers.
+Local-first command-line tooling for JPYC wallets, balances, contract calls, and transfers on EVM networks.
+
+JPYC CLI is designed for both humans and AI agents: every command can return JSON, mutating commands support dry runs, and private keys are never printed unless explicitly exported.
+
+## Requirements
+
+- Node.js `>=20.19.0`
+- RPC URLs for the networks you want to use
+- Native gas token on the sending network when broadcasting transactions
 
 ## Install
 
@@ -8,18 +16,197 @@ Local-first JPYC command-line tooling for wallets, account queries, contract cal
 npm install -g @yourbright/jpyc-cli
 ```
 
-## Usage
+Check that the binary is available:
+
+```bash
+jpyc schema list --output json
+```
+
+## Install Via Prompt
+
+If you are using an AI coding agent, give it a prompt like this:
+
+```text
+Install and verify @yourbright/jpyc-cli.
+
+Steps:
+1. Confirm Node.js is >=20.19.0.
+2. Run: npm install -g @yourbright/jpyc-cli
+3. Run: jpyc schema list --output json
+4. Create a local test wallet with:
+   jpyc wallet create --id default --output json
+5. Do not print, export, or commit private keys.
+6. If checking balances, ask me for the RPC URL or use an existing environment variable.
+```
+
+For a one-off run without global install:
+
+```bash
+npx --yes --package=@yourbright/jpyc-cli -- jpyc schema list --output json
+```
+
+## Quick Start
+
+Create a wallet:
 
 ```bash
 jpyc wallet create --id default --output json
+```
+
+List wallets:
+
+```bash
 jpyc wallet list --output json
 ```
 
-Set RPC URLs with environment variables before account or transfer commands:
+Configure an RPC URL through your shell:
 
 ```bash
 export JPYC_POLYGON_RPC_URL="https://polygon-mainnet.g.alchemy.com/v2/<key>"
-jpyc account balance --wallet default --network polygon --tokens native,jpyc --output json
 ```
 
-Wallet data is stored under `JPYC_CLI_HOME` when set, otherwise `~/.jpyc-cli`.
+Check native and JPYC balances:
+
+```bash
+jpyc account balance \
+  --wallet default \
+  --network polygon \
+  --tokens native,jpyc \
+  --output json
+```
+
+Plan a JPYC transfer:
+
+```bash
+jpyc transfer plan \
+  --network polygon \
+  --from default \
+  --to 0x0000000000000000000000000000000000000000 \
+  --amount 1 \
+  --token jpyc \
+  --output json
+```
+
+Dry-run the transfer before broadcasting:
+
+```bash
+jpyc transfer send \
+  --network polygon \
+  --from default \
+  --to 0x0000000000000000000000000000000000000000 \
+  --amount 1 \
+  --token jpyc \
+  --dry-run \
+  --output json
+```
+
+Broadcast only after checking the dry-run result:
+
+```bash
+jpyc transfer send \
+  --network polygon \
+  --from default \
+  --to 0x0000000000000000000000000000000000000000 \
+  --amount 1 \
+  --token jpyc \
+  --yes \
+  --output json
+```
+
+## Safety Notes
+
+- JPYC CLI is non-custodial. You control the wallet files.
+- Wallet data is stored locally under `JPYC_CLI_HOME` when set, otherwise `~/.jpyc-cli`.
+- The current wallet store is a local JSON file. Treat it as sensitive and do not commit it.
+- `wallet show` and `wallet list` do not print private keys.
+- `wallet export-private-key --yes` prints the private key. Use it only in a secure terminal.
+- Commands that broadcast transactions require `--yes`.
+- Prefer `transfer plan` and `transfer send --dry-run` before any real transfer.
+
+## Environment Variables
+
+| Variable | Purpose |
+| --- | --- |
+| `JPYC_CLI_HOME` | Directory for local wallet/config files. Defaults to `~/.jpyc-cli`. |
+| `JPYC_ETHEREUM_RPC_URL` | Ethereum mainnet RPC URL. |
+| `JPYC_POLYGON_RPC_URL` | Polygon mainnet RPC URL. |
+| `JPYC_AVALANCHE_RPC_URL` | Avalanche C-Chain RPC URL. |
+
+## Commands
+
+### Schemas
+
+```bash
+jpyc schema list --output json
+jpyc schema wallet.create --output json
+jpyc schema transfer.send --output json
+```
+
+### Wallets
+
+```bash
+jpyc wallet create --id default --output json
+jpyc wallet import --id imported --from-private-key-env JPYC_PRIVATE_KEY --output json
+jpyc wallet list --output json
+jpyc wallet show --id default --output json
+jpyc wallet export-private-key --id default --yes --output json
+```
+
+### Accounts
+
+```bash
+jpyc account address --wallet default --output json
+jpyc account balance --wallet default --network polygon --tokens native,jpyc --output json
+jpyc account nonce --wallet default --network polygon --output json
+```
+
+### Transfers
+
+```bash
+jpyc transfer plan --network polygon --from default --to <address> --amount 1 --token jpyc --output json
+jpyc transfer send --network polygon --from default --to <address> --amount 1 --token jpyc --dry-run --output json
+jpyc transfer send --network polygon --from default --to <address> --amount 1 --token jpyc --yes --output json
+```
+
+### Contracts
+
+```bash
+jpyc contract read \
+  --network polygon \
+  --address <contract> \
+  --abi-json '[{"type":"function","name":"symbol","stateMutability":"view","inputs":[],"outputs":[{"name":"","type":"string"}]}]' \
+  --function symbol \
+  --output json
+```
+
+## Development
+
+Install dependencies:
+
+```bash
+npm ci
+```
+
+Run checks:
+
+```bash
+npm run typecheck
+npm run build
+```
+
+Run Alchemy-backed fork tests:
+
+```bash
+export JPYC_ALCHEMY_API_KEY="<key>"
+npm run test:fork:alchemy
+```
+
+Preview the npm package:
+
+```bash
+npm pack --dry-run
+```
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -1,71 +1,71 @@
 # JPYC CLI
 
-Local-first command-line tooling for JPYC wallets, balances, contract calls, and transfers on EVM networks.
+JPYC CLI は、EVM ネットワーク上の JPYC ウォレット作成、残高確認、コントラクト呼び出し、送金をローカルで行うためのコマンドラインツールです。
 
-JPYC CLI is designed for both humans and AI agents: every command can return JSON, mutating commands support dry runs, and private keys are never printed unless explicitly exported.
+人間と AI エージェントの両方から使いやすいように、各コマンドは JSON 出力に対応し、送金などの破壊的な操作は dry-run と明示確認を前提にしています。
 
-## Requirements
+## 要件
 
 - Node.js `>=20.19.0`
-- RPC URLs for the networks you want to use
-- Native gas token on the sending network when broadcasting transactions
+- 利用するネットワークの RPC URL
+- 実送金する場合は、送信元ウォレットに対象ネットワークのネイティブガス代
 
-## Install
+## インストール
 
 ```bash
 npm install -g @yourbright/jpyc-cli
 ```
 
-Check that the binary is available:
+インストール確認:
 
 ```bash
 jpyc schema list --output json
 ```
 
-## Install Via Prompt
+## プロンプト経由でインストールする
 
-If you are using an AI coding agent, give it a prompt like this:
+AI coding agent にセットアップさせる場合は、次のようなプロンプトを渡してください。
 
 ```text
-Install and verify @yourbright/jpyc-cli.
+@yourbright/jpyc-cli をインストールして動作確認してください。
 
-Steps:
-1. Confirm Node.js is >=20.19.0.
-2. Run: npm install -g @yourbright/jpyc-cli
-3. Run: jpyc schema list --output json
-4. Create a local test wallet with:
+手順:
+1. Node.js が >=20.19.0 であることを確認する。
+2. 次を実行する: npm install -g @yourbright/jpyc-cli
+3. 次を実行して CLI を確認する: jpyc schema list --output json
+4. ローカルのテスト用ウォレットを作る:
    jpyc wallet create --id default --output json
-5. Do not print, export, or commit private keys.
-6. If checking balances, ask me for the RPC URL or use an existing environment variable.
+5. 秘密鍵を表示、export、commit しない。
+6. 残高確認が必要な場合は、RPC URL を私に確認するか、既存の環境変数を使う。
 ```
 
-For a one-off run without global install:
+グローバルインストールせずに一度だけ実行する場合:
 
 ```bash
 npx --yes --package=@yourbright/jpyc-cli -- jpyc schema list --output json
 ```
 
-## Quick Start
+## クイックスタート
 
-Create a wallet:
+ウォレットを作成:
 
 ```bash
 jpyc wallet create --id default --output json
 ```
 
-List wallets:
+ウォレット一覧:
 
 ```bash
 jpyc wallet list --output json
 ```
 
-Configure an RPC URL through your shell:
+Polygon RPC URL を設定:
 
 ```bash
 export JPYC_POLYGON_RPC_URL="https://polygon-mainnet.g.alchemy.com/v2/<key>"
 ```
 
-Check native and JPYC balances:
+ネイティブトークンと JPYC の残高確認:
 
 ```bash
 jpyc account balance \
@@ -75,7 +75,7 @@ jpyc account balance \
   --output json
 ```
 
-Plan a JPYC transfer:
+JPYC 送金内容の確認:
 
 ```bash
 jpyc transfer plan \
@@ -87,7 +87,7 @@ jpyc transfer plan \
   --output json
 ```
 
-Dry-run the transfer before broadcasting:
+送金前の dry-run:
 
 ```bash
 jpyc transfer send \
@@ -100,7 +100,7 @@ jpyc transfer send \
   --output json
 ```
 
-Broadcast only after checking the dry-run result:
+dry-run の結果を確認してから実送金:
 
 ```bash
 jpyc transfer send \
@@ -113,28 +113,28 @@ jpyc transfer send \
   --output json
 ```
 
-## Safety Notes
+## 安全上の注意
 
-- JPYC CLI is non-custodial. You control the wallet files.
-- Wallet data is stored locally under `JPYC_CLI_HOME` when set, otherwise `~/.jpyc-cli`.
-- The current wallet store is a local JSON file. Treat it as sensitive and do not commit it.
-- `wallet show` and `wallet list` do not print private keys.
-- `wallet export-private-key --yes` prints the private key. Use it only in a secure terminal.
-- Commands that broadcast transactions require `--yes`.
-- Prefer `transfer plan` and `transfer send --dry-run` before any real transfer.
+- JPYC CLI は non-custodial です。ウォレットファイルは利用者自身が管理します。
+- ウォレットデータは `JPYC_CLI_HOME` が設定されていればその配下、未設定なら `~/.jpyc-cli` に保存されます。
+- 現在のウォレットストアはローカル JSON ファイルです。秘密情報として扱い、commit しないでください。
+- `wallet show` と `wallet list` は秘密鍵を表示しません。
+- `wallet export-private-key --yes` は秘密鍵を表示します。安全な端末でのみ使ってください。
+- トランザクションを broadcast するコマンドには `--yes` が必要です。
+- 実送金前に `transfer plan` と `transfer send --dry-run` を使ってください。
 
-## Environment Variables
+## 環境変数
 
-| Variable | Purpose |
+| 変数 | 用途 |
 | --- | --- |
-| `JPYC_CLI_HOME` | Directory for local wallet/config files. Defaults to `~/.jpyc-cli`. |
-| `JPYC_ETHEREUM_RPC_URL` | Ethereum mainnet RPC URL. |
-| `JPYC_POLYGON_RPC_URL` | Polygon mainnet RPC URL. |
-| `JPYC_AVALANCHE_RPC_URL` | Avalanche C-Chain RPC URL. |
+| `JPYC_CLI_HOME` | ローカルのウォレット/config 保存先。未設定時は `~/.jpyc-cli`。 |
+| `JPYC_ETHEREUM_RPC_URL` | Ethereum mainnet RPC URL。 |
+| `JPYC_POLYGON_RPC_URL` | Polygon mainnet RPC URL。 |
+| `JPYC_AVALANCHE_RPC_URL` | Avalanche C-Chain RPC URL。 |
 
-## Commands
+## コマンド例
 
-### Schemas
+### スキーマ
 
 ```bash
 jpyc schema list --output json
@@ -142,7 +142,7 @@ jpyc schema wallet.create --output json
 jpyc schema transfer.send --output json
 ```
 
-### Wallets
+### ウォレット
 
 ```bash
 jpyc wallet create --id default --output json
@@ -152,7 +152,7 @@ jpyc wallet show --id default --output json
 jpyc wallet export-private-key --id default --yes --output json
 ```
 
-### Accounts
+### アカウント
 
 ```bash
 jpyc account address --wallet default --output json
@@ -160,7 +160,7 @@ jpyc account balance --wallet default --network polygon --tokens native,jpyc --o
 jpyc account nonce --wallet default --network polygon --output json
 ```
 
-### Transfers
+### 送金
 
 ```bash
 jpyc transfer plan --network polygon --from default --to <address> --amount 1 --token jpyc --output json
@@ -168,7 +168,7 @@ jpyc transfer send --network polygon --from default --to <address> --amount 1 --
 jpyc transfer send --network polygon --from default --to <address> --amount 1 --token jpyc --yes --output json
 ```
 
-### Contracts
+### コントラクト read
 
 ```bash
 jpyc contract read \
@@ -179,34 +179,34 @@ jpyc contract read \
   --output json
 ```
 
-## Development
+## 開発
 
-Install dependencies:
+依存関係のインストール:
 
 ```bash
 npm ci
 ```
 
-Run checks:
+チェック:
 
 ```bash
 npm run typecheck
 npm run build
 ```
 
-Run Alchemy-backed fork tests:
+Alchemy RPC を使った fork test:
 
 ```bash
 export JPYC_ALCHEMY_API_KEY="<key>"
 npm run test:fork:alchemy
 ```
 
-Preview the npm package:
+npm package の中身を確認:
 
 ```bash
 npm pack --dry-run
 ```
 
-## License
+## ライセンス
 
 MIT

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ AI coding agent にセットアップさせる場合は、次のようなプロ�
 npx --yes --package=@yourbright/jpyc-cli -- jpyc schema list --output json
 ```
 
+## Codex Skill としてインストールする
+
+Codex に JPYC CLI の安全な使い方を覚えさせたい場合は、この repo の skill を GitHub 経由でインストールできます。
+
+```bash
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo yourbright-jp/jpyc-cli \
+  --path skills/jpyc-cli
+```
+
+インストール後、Codex を再起動してから `$jpyc-cli` を指定してください。
+
 ## クイックスタート
 
 ウォレットを作成:

--- a/README.md
+++ b/README.md
@@ -47,12 +47,10 @@ npx --yes --package=@yourbright/jpyc-cli -- jpyc schema list --output json
 
 ## Codex Skill としてインストールする
 
-Codex に JPYC CLI の安全な使い方を覚えさせたい場合は、この repo の skill を GitHub 経由でインストールできます。
+Codex に JPYC CLI の安全な使い方を覚えさせたい場合は、GitHub CLI `v2.90.0` 以降の `gh skill` でインストールできます。
 
 ```bash
-python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo yourbright-jp/jpyc-cli \
-  --path skills/jpyc-cli
+gh skill install yourbright-jp/jpyc-cli jpyc-cli --agent codex --scope user
 ```
 
 インストール後、Codex を再起動してから `$jpyc-cli` を指定してください。

--- a/docs/superpowers/specs/2026-04-26-jpyc-cli-release-video-design.md
+++ b/docs/superpowers/specs/2026-04-26-jpyc-cli-release-video-design.md
@@ -1,0 +1,146 @@
+# JPYC-CLI Release Video Design
+
+## Summary
+
+Create a 30-40 second 1920x1080 HyperFrames release announcement video for JPYC-CLI.
+
+The approved direction is **Flowing Agent Demo**: a light, fluid narrative showing an AI agent safely using JPYC-CLI through schemas, local wallet checks, transfer planning, and dry-run guardrails.
+
+## Goals
+
+- Announce JPYC-CLI as local-first command-line tooling for JPYC.
+- Show that humans and AI agents can use the same safe command surface.
+- Emphasize JSON output, dry runs, local wallet control, and explicit confirmation before broadcasts.
+- Keep the video understandable without requiring prior JPYC-CLI knowledge.
+
+## Audience
+
+- Developers evaluating JPYC-CLI.
+- AI-agent users who want a safe CLI surface for JPYC workflows.
+- JPYC ecosystem users who need a concise release overview.
+
+## Visual Identity
+
+Use JPYC info brand cues from `https://jpyc-info.com/`.
+
+- Mood: fluid, light, technical, trustworthy.
+- Canvas: light.
+- Background: `#eef2ff`.
+- Surface: `#ffffff`.
+- Primary accent: `#2563eb`.
+- Ink: `#0f172a`.
+- Muted text: `#64748b`.
+- Border: `#e2e8f0`.
+- Flow accent: teal `#0d9488`.
+- Typography: `Noto Sans JP`, `Inter`, system sans for UI text; system monospace for terminal and JSON.
+
+Avoid dark cyberpunk styling, neon-heavy palettes, generic purple gradients, or dense command screens that require pausing to read.
+
+## Narrative Arc
+
+The video follows one agent-safe workflow:
+
+1. JPYC-CLI is released.
+2. An AI agent checks the command surface through schema output.
+3. The agent creates or selects a local wallet and checks account state.
+4. The agent plans a JPYC transfer.
+5. The dry-run guardrail appears before any broadcast.
+6. The video closes with the install command and release message.
+
+## Storyboard
+
+### Scene 1: Release Title, 0-5s
+
+Show a clean JPYC-CLI release title over a light JPYC info-inspired canvas. Soft blue and teal flow lines move behind white UI surfaces.
+
+Primary copy:
+
+- `JPYC-CLI`
+- `Local-first JPYC tooling`
+- `For humans and AI agents`
+
+### Scene 2: Agent Reads the Command Surface, 5-12s
+
+Show an AI agent node connected to a terminal card. The terminal reveals schema-oriented usage.
+
+Representative command:
+
+```bash
+jpyc schema list --output json
+```
+
+Message:
+
+- `JSON-first commands`
+- `Predictable for scripts and agents`
+
+### Scene 3: Local Wallet and Account Checks, 12-21s
+
+Show wallet and balance cards flowing left to right. Keep private-key handling implicit and safe; do not display private keys.
+
+Representative commands:
+
+```bash
+jpyc wallet create --id default --output json
+jpyc account balance --wallet default --network polygon --tokens native,jpyc --output json
+```
+
+Message:
+
+- `Local wallet control`
+- `No private keys printed by default`
+
+### Scene 4: Plan and Dry-Run Guardrails, 21-31s
+
+Show a transfer path from agent to CLI to JPYC. The plan appears first, then dry-run appears as a visible safety gate before sending.
+
+Representative commands:
+
+```bash
+jpyc transfer plan --network polygon --from default --to <address> --amount 1 --token jpyc --output json
+jpyc transfer send --network polygon --from default --to <address> --amount 1 --token jpyc --dry-run --output json
+```
+
+Message:
+
+- `Plan before send`
+- `Dry-run before broadcast`
+- `Broadcast requires explicit confirmation`
+
+### Scene 5: Install CTA, 31-38s
+
+Close with a calm release CTA and install command.
+
+Primary copy:
+
+- `JPYC-CLI is ready`
+- `npm install -g @yourbright/jpyc-cli`
+- `Local-first JPYC tooling for humans and agents`
+
+## HyperFrames Implementation
+
+- Use a single root HyperFrames composition at 1920x1080.
+- Use HTML/CSS as the layout source of truth, then add GSAP `from()` entrances.
+- Use scene transitions between all scenes; no jump cuts.
+- Use fluid line and card motion to connect the agent, terminal, wallet, balance, plan, and dry-run moments.
+- Register all timelines synchronously with `window.__timelines`.
+- Do not use random or time-based animation logic.
+- Do not animate clip dimensions directly.
+
+## Validation
+
+Before rendering final video:
+
+- Run `npx hyperframes lint`.
+- Run `npx hyperframes inspect --samples 15`.
+- Preview locally with `npx hyperframes preview`.
+- Render a draft MP4 first.
+- Render final MP4 at standard or high quality after visual checks pass.
+
+## Out of Scope
+
+- Real transaction broadcasting in the video.
+- Displaying private keys.
+- Live RPC calls or captured terminal recordings.
+- Voiceover for the initial video.
+- Vertical or square social variants for the initial video.

--- a/skills/jpyc-cli/SKILL.md
+++ b/skills/jpyc-cli/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: jpyc-cli
+description: Use when Codex needs to install or operate @yourbright/jpyc-cli for JPYC wallet creation, wallet listing, address/balance checks, transfer planning, dry-runs, JPYC/native token transfers, contract reads/writes, or npm package verification. Trigger whenever the user asks to use JPYC CLI, install JPYC CLI, check JPYC balances, create/import a JPYC wallet, send JPYC, or prepare commands for an AI agent to operate JPYC CLI safely.
+---
+
+# JPYC CLI
+
+Use JPYC CLI as a local-first, non-custodial command-line tool. Prefer JSON output for every command. Treat wallet files and private keys as secrets.
+
+## Install
+
+Require Node.js `>=20.19.0`.
+
+```bash
+node --version
+npm install -g @yourbright/jpyc-cli
+jpyc schema list --output json
+```
+
+For one-off use without global install:
+
+```bash
+npx --yes --package=@yourbright/jpyc-cli -- jpyc schema list --output json
+```
+
+If Node is too old, stop and ask the user whether to switch/install Node 20.19+ before continuing.
+
+## Safety Rules
+
+- Do not print, export, paste, or commit private keys unless the user explicitly asks for private key export.
+- Never run `wallet export-private-key --yes` without explicit user approval.
+- Never broadcast a transaction without first running `transfer plan` and `transfer send --dry-run`.
+- Before any broadcast command with `--yes`, restate network, from wallet/address, recipient, token, amount, and gas estimate, then wait for explicit confirmation.
+- Use a dedicated `JPYC_CLI_HOME` for experiments when possible, for example `/tmp/jpyc-cli-local`.
+- Do not commit wallet stores, `.env`, `.env.local`, RPC keys, or generated local wallet files.
+- If using mainnet RPC, be explicit about the network: `ethereum`, `polygon`, or `avalanche`.
+
+## Environment
+
+JPYC CLI reads RPC URLs from environment variables:
+
+```bash
+export JPYC_ETHEREUM_RPC_URL="https://..."
+export JPYC_POLYGON_RPC_URL="https://..."
+export JPYC_AVALANCHE_RPC_URL="https://..."
+```
+
+Wallet/config storage:
+
+```bash
+export JPYC_CLI_HOME="$HOME/.jpyc-cli"
+```
+
+Use `JPYC_CLI_HOME=/tmp/jpyc-cli-local` for disposable testing.
+
+## Wallet Workflow
+
+Create a wallet:
+
+```bash
+jpyc wallet create --id default --output json
+```
+
+List wallets:
+
+```bash
+jpyc wallet list --output json
+```
+
+Show public wallet metadata:
+
+```bash
+jpyc wallet show --id default --output json
+```
+
+Import from an environment variable:
+
+```bash
+JPYC_PRIVATE_KEY="0x..." jpyc wallet import --id imported --from-private-key-env JPYC_PRIVATE_KEY --output json
+```
+
+## Balance Workflow
+
+Check address:
+
+```bash
+jpyc account address --wallet default --output json
+```
+
+Check native and JPYC balances on Polygon:
+
+```bash
+jpyc account balance --wallet default --network polygon --tokens native,jpyc --output json
+```
+
+If balance checks fail with `RPC_URL_MISSING`, ask for the relevant RPC URL or derive it from an approved existing environment variable.
+
+## Transfer Workflow
+
+Always perform these steps in order.
+
+1. Plan:
+
+```bash
+jpyc transfer plan --network polygon --from default --to <address> --amount 1 --token jpyc --output json
+```
+
+2. Dry-run:
+
+```bash
+jpyc transfer send --network polygon --from default --to <address> --amount 1 --token jpyc --dry-run --output json
+```
+
+3. Ask for explicit confirmation. Include:
+
+- network
+- from wallet/address
+- recipient
+- token and amount
+- gas estimate
+- whether this is mainnet
+
+4. Broadcast only after confirmation:
+
+```bash
+jpyc transfer send --network polygon --from default --to <address> --amount 1 --token jpyc --yes --output json
+```
+
+After broadcasting, report the transaction hash and re-check balances if the user wants confirmation.
+
+## Contract Read
+
+Use `contract.read` for view calls. Keep ABI JSON minimal.
+
+```bash
+jpyc contract read \
+  --network polygon \
+  --address <contract> \
+  --abi-json '[{"type":"function","name":"symbol","stateMutability":"view","inputs":[],"outputs":[{"name":"","type":"string"}]}]' \
+  --function symbol \
+  --output json
+```
+
+## Development and Package Verification
+
+When working inside the `yourbright-jp/jpyc-cli` repository:
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+npm pack --dry-run
+```
+
+Alchemy-backed fork tests require a keyed Alchemy app with Ethereum, Polygon, and Avalanche enabled:
+
+```bash
+export JPYC_ALCHEMY_API_KEY="<key>"
+npm run test:fork:alchemy
+```
+
+Do not publish to npm unless the user explicitly asks. Before publishing, run `npm publish --dry-run --access public`.

--- a/skills/jpyc-cli/agents/openai.yaml
+++ b/skills/jpyc-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "JPYC CLI"
+  short_description: "Operate JPYC CLI safely"
+  default_prompt: "Use $jpyc-cli to install JPYC CLI, create a wallet, check balances, and dry-run transfers safely."


### PR DESCRIPTION
## Summary
- Rewrite README in Japanese with npm install, npx, prompt-based install, command examples, safety notes, and development workflow
- Add an installable Codex/Agent Skills skill at `skills/jpyc-cli` for safe JPYC CLI operation
- Document the short `gh skill install yourbright-jp/jpyc-cli jpyc-cli --agent codex --scope user` install path

## Validation
- `python3 /mnt/c/Users/guruj/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/jpyc-cli`
- `git diff --check`
- `npx --yes --package=@yourbright/jpyc-cli -- jpyc schema list --output json`
- `python3 /mnt/c/Users/guruj/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --repo yourbright-jp/jpyc-cli --ref codex/readme-npm-usage --path skills/jpyc-cli --dest /tmp/jpyc-skill-install-test-69f4afe`
- `python3 /mnt/c/Users/guruj/.codex/skills/.system/skill-creator/scripts/quick_validate.py /tmp/jpyc-skill-install-test-69f4afe/jpyc-cli`

Note: local `gh` is `2.45.0`, so `gh skill` itself is not available in this environment. The repository layout matches the `skills/*/SKILL.md` auto-discovery convention documented for `gh skill install`.