### PR TITLE
[codex] Reject unknown transfer tokens

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,6 +45,7 @@ type WalletStore = {
 };
 
 type NetworkId = 'ethereum' | 'polygon' | 'avalanche';
+type TokenId = 'native' | 'jpyc';
 
 type NetworkConfig = {
   name: NetworkId;
@@ -163,6 +164,12 @@ function flagBool(flags: Record<string, string | boolean>, key: string): boolean
 function asNetwork(value: string | undefined): NetworkId {
   if (value === 'ethereum' || value === 'polygon' || value === 'avalanche') return value;
   throw new CliError(2, 'UNKNOWN_NETWORK', `Unsupported network: ${value ?? '(missing)'}`);
+}
+
+function asToken(value: string | undefined): TokenId {
+  const token = value ?? 'jpyc';
+  if (token === 'native' || token === 'jpyc') return token;
+  throw new CliError(2, 'INVALID_ARGUMENT', `Unsupported --token: ${token}. Supported values: native, jpyc`);
 }
 
 function asAddress(value: string | undefined, label: string): Address {
@@ -498,7 +505,7 @@ class CliRuntime {
     const from = flagString(flags, 'from');
     const to = asAddress(flagString(flags, 'to'), '--to');
     const amount = flagString(flags, 'amount');
-    const token = flagString(flags, 'token') ?? 'jpyc';
+    const token = asToken(flagString(flags, 'token'));
     if (!from || !amount) throw new CliError(2, 'INVALID_ARGUMENT', '--from and --amount are required');
     return { networkId, from, to, amount, token };
   }

--- a/tests/transfer-token-validation.test.ts
+++ b/tests/transfer-token-validation.test.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { createJpycCli } from '../src/cli/index.js';
+
+describe('transfer token validation', () => {
+  it('rejects unknown transfer tokens instead of treating them as JPYC', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'jpyc-cli-token-validation-'));
+    const cli = createJpycCli({ homeDir, env: {} });
+
+    try {
+      const result = await cli.run([
+        'transfer',
+        'plan',
+        '--network',
+        'polygon',
+        '--from',
+        'default',
+        '--to',
+        '0x000000000000000000000000000000000000bEEF',
+        '--amount',
+        '1',
+        '--token',
+        'usdc',
+        '--output',
+        'json',
+      ]);
+      const parsed = JSON.parse(result.stdout);
+
+      expect(result.exitCode).toBe(2);
+      expect(parsed.error.code).toBe('INVALID_ARGUMENT');
+      expect(parsed.error.message).toContain('--token');
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add explicit transfer token validation for `native` and `jpyc`
- Reject unknown `--token` values with `INVALID_ARGUMENT` instead of treating them as JPYC
- Add a regression test for `--token usdc`

Fixes #8.

## Validation

- `TMPDIR=/tmp npx vitest run tests/transfer-token-validation.test.ts` - 1 passed
- `npm run typecheck` - passed
- `npm run build` - passed
- `TMPDIR=/tmp npx vitest run tests/transfer-token-validation.test.ts tests/cli-main.test.ts tests/package-publish.test.ts` - 7 passed