### PR TITLE
[codex] Fail closed on invalid wallet store

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -312,11 +312,19 @@ class CliRuntime {
   }
 
   private async readWalletStore(): Promise<WalletStore> {
+    let raw: string;
     try {
-      const raw = await readFile(this.walletsPath(), 'utf8');
+      raw = await readFile(this.walletsPath(), 'utf8');
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        return { wallets: [] };
+      }
+      throw new CliError(1, 'WALLET_STORE_READ_FAILED', `Unable to read wallet store: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    try {
       return JSON.parse(raw) as WalletStore;
-    } catch {
-      return { wallets: [] };
+    } catch (error) {
+      throw new CliError(1, 'WALLET_STORE_INVALID', `Wallet store is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 

--- a/tests/wallet-store-errors.test.ts
+++ b/tests/wallet-store-errors.test.ts
@@ -1,0 +1,28 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { createJpycCli } from '../src/cli/index.js';
+
+describe('wallet store error handling', () => {
+  it('fails closed and preserves the store when wallets.json is invalid JSON', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'jpyc-cli-wallet-store-'));
+    const walletsPath = join(homeDir, 'wallets.json');
+    await mkdir(homeDir, { recursive: true });
+    await writeFile(walletsPath, '{ invalid json\n', 'utf8');
+
+    const cli = createJpycCli({ homeDir, env: {} });
+
+    try {
+      const result = await cli.run(['wallet', 'create', '--id', 'default', '--output', 'json']);
+      const parsed = JSON.parse(result.stdout);
+
+      expect(result.exitCode).toBe(1);
+      expect(parsed.error.code).toBe('WALLET_STORE_INVALID');
+      await expect(readFile(walletsPath, 'utf8')).resolves.toBe('{ invalid json\n');
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Treat only missing `wallets.json` as an empty wallet store
- Return explicit wallet-store errors for invalid JSON and read failures
- Add a regression test proving invalid wallet stores are not overwritten by `wallet create`

Fixes #9.

## Validation

- `TMPDIR=/tmp npx vitest run tests/wallet-store-errors.test.ts` - 1 passed
- `npm run typecheck` - passed
- `npm run build` - passed
- `TMPDIR=/tmp npx vitest run tests/wallet-store-errors.test.ts tests/cli-main.test.ts tests/package-publish.test.ts` - 7 passed