### PR TITLE
[codex] Harden wallet store permissions

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
 import { join } from 'node:path';
 import {
@@ -313,6 +313,7 @@ class CliRuntime {
 
   private async ensureHome() {
     await mkdir(this.homeDir, { recursive: true });
+    await chmod(this.homeDir, 0o700);
   }
 
   private walletsPath() {
@@ -342,7 +343,20 @@ class CliRuntime {
 
   private async writeWalletStore(store: WalletStore) {
     await this.ensureHome();
+    try {
+      const status = await lstat(this.walletsPath());
+      if (status.isSymbolicLink() || !status.isFile()) {
+        throw new CliError(1, 'WALLET_STORE_UNSAFE', 'Wallet store must be a regular file');
+      }
+      await chmod(this.walletsPath(), 0o600);
+    } catch (error) {
+      if (error instanceof CliError) throw error;
+      if (!(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')) {
+        throw new CliError(1, 'WALLET_STORE_UNSAFE', `Unable to verify wallet store permissions: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
     await writeFile(this.walletsPath(), `${jsonStringify(store)}\n`, { mode: 0o600 });
+    await chmod(this.walletsPath(), 0o600);
   }
 
   private async findWallet(id: string | undefined): Promise<WalletRecord> {

--- a/tests/wallet-store-permissions.test.ts
+++ b/tests/wallet-store-permissions.test.ts
@@ -1,0 +1,55 @@
+import { chmod, lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { createJpycCli } from '../src/cli/index.js';
+
+function modeBits(mode: number) {
+  return mode & 0o777;
+}
+
+describe('wallet store permissions', () => {
+  it('tightens existing wallet store and home directory permissions before saving secrets', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'jpyc-cli-wallet-perms-'));
+    const walletsPath = join(homeDir, 'wallets.json');
+    await writeFile(walletsPath, '{"wallets":[]}\n', { mode: 0o644 });
+    await chmod(walletsPath, 0o644);
+    await chmod(homeDir, 0o755);
+
+    const cli = createJpycCli({ homeDir, env: { JPYC_KEYSTORE_PASSWORD: 'test-password' } });
+
+    try {
+      const result = await cli.run(['wallet', 'create', '--id', 'default', '--output', 'json']);
+
+      expect(result.exitCode).toBe(0);
+      expect(modeBits((await lstat(homeDir)).mode)).toBe(0o700);
+      expect(modeBits((await lstat(walletsPath)).mode)).toBe(0o600);
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinked wallet stores instead of writing secrets through them', async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), 'jpyc-cli-wallet-symlink-'));
+    const targetDir = await mkdtemp(join(tmpdir(), 'jpyc-cli-wallet-target-'));
+    const walletsPath = join(homeDir, 'wallets.json');
+    const targetPath = join(targetDir, 'wallets.json');
+    await mkdir(homeDir, { recursive: true });
+    await writeFile(targetPath, '{"wallets":[]}\n', 'utf8');
+    await symlink(targetPath, walletsPath);
+
+    const cli = createJpycCli({ homeDir, env: { JPYC_KEYSTORE_PASSWORD: 'test-password' } });
+
+    try {
+      const result = await cli.run(['wallet', 'create', '--id', 'default', '--output', 'json']);
+      const parsed = JSON.parse(result.stdout);
+
+      expect(result.exitCode).toBe(1);
+      expect(parsed.error.code).toBe('WALLET_STORE_UNSAFE');
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(targetDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Force the CLI home directory to `0700` when preparing wallet storage
- Verify `wallets.json` is a regular file and reject symlinked/non-file stores before writing secrets
- Tighten existing and newly written wallet stores to `0600`
- Add regression tests for loose existing permissions and symlinked stores

Fixes #7.

## Validation

- `TMPDIR=/tmp npx vitest run tests/wallet-store-permissions.test.ts` - 2 passed
- `npm run typecheck` - passed
- `npm run build` - passed
- `TMPDIR=/tmp npx vitest run tests/wallet-store-permissions.test.ts tests/cli-main.test.ts tests/package-publish.test.ts` - 8 passed