### PR TITLE
[codex] Validate RPC chain ids

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import {
   type Hex,
 } from 'viem';
 import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts';
+import { avalanche, mainnet, polygon } from 'viem/chains';
 
 export type CliRunResult = {
   exitCode: number;
@@ -60,6 +61,12 @@ const NETWORKS: Record<NetworkId, NetworkConfig> = {
   polygon: { name: 'polygon', chainId: 137, rpcUrlEnv: 'JPYC_POLYGON_RPC_URL', nativeSymbol: 'POL' },
   avalanche: { name: 'avalanche', chainId: 43114, rpcUrlEnv: 'JPYC_AVALANCHE_RPC_URL', nativeSymbol: 'AVAX' },
 };
+
+const NETWORK_CHAINS = {
+  ethereum: mainnet,
+  polygon,
+  avalanche,
+} as const;
 
 const ERC20_ABI = [
   { type: 'function', name: 'symbol', stateMutability: 'view', inputs: [], outputs: [{ name: '', type: 'string' }] },
@@ -324,7 +331,17 @@ class CliRuntime {
     const rpcEnv = this.configGet(`networks.${networkId}.rpcUrlEnv`) ?? network.rpcUrlEnv;
     const rpcUrl = this.env[rpcEnv];
     if (!rpcUrl) throw new CliError(2, 'RPC_URL_MISSING', `${rpcEnv} is required`);
-    return createPublicClient({ transport: http(rpcUrl) });
+    return createPublicClient({ chain: NETWORK_CHAINS[networkId], transport: http(rpcUrl) });
+  }
+
+  private async checkedPublicClient(networkId: NetworkId) {
+    const client = this.publicClient(networkId);
+    const expected = NETWORKS[networkId].chainId;
+    const actual = await client.getChainId();
+    if (actual !== expected) {
+      throw new CliError(1, 'RPC_CHAIN_ID_MISMATCH', `RPC chainId mismatch for ${networkId}: expected ${expected}, got ${actual}`);
+    }
+    return client;
   }
 
   private walletClient(networkId: NetworkId, wallet: WalletRecord) {
@@ -333,7 +350,7 @@ class CliRuntime {
     const rpcUrl = this.env[rpcEnv];
     if (!rpcUrl) throw new CliError(2, 'RPC_URL_MISSING', `${rpcEnv} is required`);
     const account = privateKeyToAccount(wallet.privateKey);
-    return createWalletClient({ account, transport: http(rpcUrl) });
+    return createWalletClient({ account, chain: NETWORK_CHAINS[networkId], transport: http(rpcUrl) });
   }
 
   private configGet(key: string | undefined) {
@@ -406,7 +423,7 @@ class CliRuntime {
 
   private async accountBalance(walletId: string | undefined, networkId: NetworkId, tokens: string | undefined) {
     const wallet = await this.findWallet(walletId);
-    const client = this.publicClient(networkId);
+    const client = await this.checkedPublicClient(networkId);
     const requested = (tokens ?? 'native').split(',').map((token) => token.trim());
     const balances = [];
     if (requested.includes('native')) {
@@ -427,7 +444,7 @@ class CliRuntime {
 
   private async accountNonce(walletId: string | undefined, networkId: NetworkId) {
     const wallet = await this.findWallet(walletId);
-    const client = this.publicClient(networkId);
+    const client = await this.checkedPublicClient(networkId);
     const nonce = await client.getTransactionCount({ address: wallet.address });
     return success({ network: networkId, address: wallet.address, nonce: nonce.toString() });
   }
@@ -448,7 +465,7 @@ class CliRuntime {
     const address = asAddress(flagString(flags, 'address'), '--address');
     const functionName = flagString(flags, 'function');
     if (!functionName) throw new CliError(2, 'INVALID_ARGUMENT', '--function is required');
-    const result = await (this.publicClient(networkId) as any).readContract({
+    const result = await ((await this.checkedPublicClient(networkId)) as any).readContract({
       address,
       abi: this.abiFromFlags(flags),
       functionName,
@@ -466,14 +483,14 @@ class CliRuntime {
     const abi = this.abiFromFlags(flags);
     const args = this.argsFromFlags(flags);
     const data = encodeFunctionData({ abi, functionName, args });
-    const client = this.publicClient(networkId);
+    const client = await this.checkedPublicClient(networkId);
     const base = { network: networkId, chainId: NETWORKS[networkId].chainId, to: address };
     if (flagBool(flags, 'dry-run')) {
       const gas = await client.estimateGas({ account: wallet.address, to: address, data });
       return success({ ok: true, command: 'contract.write', mode: 'dry-run', broadcast: false, tx: { ...base, gas: gas.toString() } });
     }
     if (!flagBool(flags, 'yes')) return failure(8, 'USER_CONFIRMATION_REQUIRED', 'Use --yes to broadcast contract write');
-    const txHash = await (this.walletClient(networkId, wallet) as any).writeContract({ address, abi, functionName, args, chain: null });
+    const txHash = await (this.walletClient(networkId, wallet) as any).writeContract({ address, abi, functionName, args, chain: NETWORK_CHAINS[networkId] });
     await client.waitForTransactionReceipt({ hash: txHash });
     return success({ ok: true, command: 'contract.write', broadcast: true, txHash, tx: base });
   }
@@ -482,13 +499,13 @@ class CliRuntime {
     const networkId = asNetwork(flagString(flags, 'network'));
     const wallet = await this.findWallet(flagString(flags, 'wallet'));
     const bytecode = asHex(flagString(flags, 'bytecode'), '--bytecode');
-    const client = this.publicClient(networkId);
+    const client = await this.checkedPublicClient(networkId);
     if (flagBool(flags, 'dry-run')) {
       const gas = await client.estimateGas({ account: wallet.address, data: bytecode });
       return success({ ok: true, command: 'contract.deploy', mode: 'dry-run', broadcast: false, tx: { network: networkId, chainId: NETWORKS[networkId].chainId, gas: gas.toString() } });
     }
     if (!flagBool(flags, 'yes')) return failure(8, 'USER_CONFIRMATION_REQUIRED', 'Use --yes to deploy contract');
-    const txHash = await (this.walletClient(networkId, wallet) as any).deployContract({ abi: [], bytecode, chain: null });
+    const txHash = await (this.walletClient(networkId, wallet) as any).deployContract({ abi: [], bytecode, chain: NETWORK_CHAINS[networkId] });
     const receipt = await client.waitForTransactionReceipt({ hash: txHash });
     return success({ ok: true, command: 'contract.deploy', broadcast: true, txHash, contractAddress: receipt.contractAddress });
   }
@@ -522,7 +539,7 @@ class CliRuntime {
   private async transferEstimate(flags: Record<string, string | boolean>) {
     const { networkId, from, to, amount, token } = this.transferParams(flags);
     const wallet = await this.findWallet(from);
-    const client = this.publicClient(networkId);
+    const client = await this.checkedPublicClient(networkId);
     const gas = token === 'native'
       ? await client.estimateGas({ account: wallet.address, to, value: parseEther(amount) })
       : await client.estimateGas({
@@ -536,7 +553,7 @@ class CliRuntime {
   private async transferSend(flags: Record<string, string | boolean>) {
     const { networkId, from, to, amount, token } = this.transferParams(flags);
     const wallet = await this.findWallet(from);
-    const client = this.publicClient(networkId);
+    const client = await this.checkedPublicClient(networkId);
     const isNative = token === 'native';
     const tokenInfo = isNative
       ? { symbol: NETWORKS[networkId].nativeSymbol, type: 'native' }
@@ -554,8 +571,8 @@ class CliRuntime {
     if (!flagBool(flags, 'yes')) return failure(8, 'USER_CONFIRMATION_REQUIRED', 'Use --yes to broadcast transfer');
     const walletClient = this.walletClient(networkId, wallet);
     const txHash = isNative
-      ? await (walletClient as any).sendTransaction({ to, value: parseEther(amount), chain: null })
-      : await (walletClient as any).writeContract({ address: JPYC_CONTRACT_ADDRESS, abi: ERC20_ABI, functionName: 'transfer', args: [to, parseUnits(amount, 18)], chain: null });
+      ? await (walletClient as any).sendTransaction({ to, value: parseEther(amount), chain: NETWORK_CHAINS[networkId] })
+      : await (walletClient as any).writeContract({ address: JPYC_CONTRACT_ADDRESS, abi: ERC20_ABI, functionName: 'transfer', args: [to, parseUnits(amount, 18)], chain: NETWORK_CHAINS[networkId] });
     await client.waitForTransactionReceipt({ hash: txHash });
     return success({ ok: true, command: 'transfer.send', broadcast: true, txHash, token: tokenInfo });
   }

--- a/tests/rpc-chain-id-validation.test.ts
+++ b/tests/rpc-chain-id-validation.test.ts
@@ -1,0 +1,73 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createJpycCli } from '../src/cli/index.js';
+
+const servers: Array<ReturnType<typeof createServer>> = [];
+
+function readBody(request: IncomingMessage) {
+  return new Promise<string>((resolve, reject) => {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk) => {
+      body += chunk;
+    });
+    request.on('end', () => resolve(body));
+    request.on('error', reject);
+  });
+}
+
+async function startRpcServer(chainIdHex: `0x${string}`) {
+  const seenMethods: string[] = [];
+  const server = createServer(async (request: IncomingMessage, response: ServerResponse) => {
+    const payload = JSON.parse(await readBody(request)) as { id: number; method: string };
+    seenMethods.push(payload.method);
+    const result = payload.method === 'eth_chainId' ? chainIdHex : '0x0';
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify({ jsonrpc: '2.0', id: payload.id, result }));
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Unable to start test RPC server');
+  return { url: `http://127.0.0.1:${address.port}`, seenMethods };
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+});
+
+describe('RPC chain id validation', () => {
+  it('rejects RPC endpoints whose chainId does not match the selected network', async () => {
+    const rpc = await startRpcServer('0x1');
+    const homeDir = await mkdtemp(join(tmpdir(), 'jpyc-cli-chain-id-'));
+    const cli = createJpycCli({ homeDir, env: { JPYC_POLYGON_RPC_URL: rpc.url } });
+
+    try {
+      await cli.run(['wallet', 'create', '--id', 'default', '--output', 'json']);
+      const result = await cli.run([
+        'account',
+        'balance',
+        '--wallet',
+        'default',
+        '--network',
+        'polygon',
+        '--tokens',
+        'native',
+        '--output',
+        'json',
+      ]);
+      const parsed = JSON.parse(result.stdout);
+
+      expect(result.exitCode).toBe(1);
+      expect(parsed.error.code).toBe('RPC_CHAIN_ID_MISMATCH');
+      expect(parsed.error.message).toContain('expected 137');
+      expect(rpc.seenMethods).toContain('eth_chainId');
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Attach explicit viem chain definitions to public and wallet clients
- Check `eth_chainId` against the selected network before reads, estimates, deploys, writes, and transfers
- Remove broadcast calls using `chain: null`
- Add a regression test for Polygon commands pointed at an Ethereum-chain RPC

Fixes #5.

## Validation

- `TMPDIR=/tmp npx vitest run tests/rpc-chain-id-validation.test.ts` - 1 passed
- `npm run typecheck` - passed
- `npm run build` - passed
- `TMPDIR=/tmp npx vitest run tests/cli-main.test.ts tests/package-publish.test.ts` - 6 passed
- `TMPDIR=/tmp npx vitest run tests/rpc-chain-id-validation.test.ts tests/cli-main.test.ts tests/package-publish.test.ts` - 7 passed