### PR TITLE
[codex] Fix ws Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,9 +1465,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "dependencies": {
     "@noble/ciphers": "^2.2.0",
     "viem": "^2.48.4"
+  },
+  "overrides": {
+    "ws": "8.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- add an npm override for transitive `ws` so the resolved version is `8.21.0`
- refresh `package-lock.json` with the patched `ws` tarball and integrity

## Validation
- `npm install --package-lock-only`
- `npm ci`
- `npm ls ws --all`
- `npm audit --audit-level=moderate`
- `npm run typecheck`
- `npm run build`
- `npm test` fails on Windows before Vitest because the npm script uses Unix-style env assignment
- PowerShell equivalent fork test starts but fails locally because `anvil` is not installed; CI installs Foundry for fork tests

Fixes Dependabot alert #4 (`ws: Memory exhaustion DoS from tiny fragments and data chunks`).